### PR TITLE
Fix the urban/rural classification importer

### DIFF
--- a/ddl/types/rural_urban_classification.sql
+++ b/ddl/types/rural_urban_classification.sql
@@ -1,25 +1,31 @@
 drop type if exists rural_urban_classification;
 
+/*
+ * the classifications are now all upper case because the Scottish exist in
+ * multiple combinations of capitalisation, eg 'Large Urban Area', 'Large Urban
+ * area' and 'Large urban area'
+ */
 create type rural_urban_classification as enum (
 	-- https://www.gov.uk/government/collections/rural-urban-classification
-	'Rural village in a sparse setting',
-	'Urban major conurbation',
-	'Urban city and town',
-	'Rural town and fringe',
-	'Rural hamlet and isolated dwellings',
-	'Rural town and fringe in a sparse setting',
-	'Urban minor conurbation',
-	'Rural village',
-	'Urban city and town in a sparse setting',
-	'Rural hamlet and isolated dwellings in a sparse setting',
+	'RURAL VILLAGE IN A SPARSE SETTING',
+	'URBAN MAJOR CONURBATION',
+	'URBAN CITY AND TOWN',
+	'RURAL TOWN AND FRINGE',
+	'RURAL HAMLET AND ISOLATED DWELLINGS',
+	'RURAL TOWN AND FRINGE IN A SPARSE SETTING',
+	'URBAN MINOR CONURBATION',
+	'RURAL VILLAGE',
+	'URBAN CITY AND TOWN IN A SPARSE SETTING',
+	'RURAL HAMLET AND ISOLATED DWELLINGS IN A SPARSE SETTING',
 
 	-- ¯\_(ツ)_/¯
-	'Postcode in NI/Channel Is/IoM (pseudo)',
+	'POSTCODE IN NI/CHANNEL IS/IOM (PSEUDO)',
+	'(PSEUDO) CHANNEL ISLANDS/ISLE OF MAN',
 
 	-- https://www2.gov.scot/Topics/Statistics/About/Methodology/UrbanRuralClassification
-	'Large urban area (Scotland)',
-	'Remote rural (Scotland)',
-	'Accessible rural (Scotland)',
-	'Remote small town (Scotland)',
-	'Other urban area (Scotland)'
+	'ACCESSIBLE RURAL',
+	'LARGE URBAN AREA',
+	'OTHER URBAN AREA',
+	'REMOTE RURAL',
+	'REMOTE SMALL TOWN'
 );

--- a/dml/import_schools.sql
+++ b/dml/import_schools.sql
@@ -115,7 +115,20 @@ select
 	nullif(sr."StatutoryLowAge", '')::integer,
 	nullif(sr."StatutoryHighAge", '')::integer,
 	nullif(sr."SchoolCapacity", '')::integer,
-	nullif(sr."UrbanRural (name)", '')::rural_urban_classification,
+	/*
+	 * upper case all of the classifications to standardise
+	 */
+	upper(
+		replace(
+			replace(
+				nullif(sr."UrbanRural (name)", ''),
+				'(England/Wales) ',
+				''
+			),
+			'(Scotland) ',
+			''
+		)
+	)::rural_urban_classification,
 	nullif(ear."MailEmail", '')
 
 from


### PR DESCRIPTION
The classifications appear to have changed and the changes have made the cause problems in addition to the data uglier and less-consistent:

* prefixing some with (England/Wales) pushes the enum text length over
  64 characters and PostgreSQL won't allow it
* the capitalisation of the 'same' value isn't consistent, sometimes all
  words are capitalised and others just the first

Now we are uppercasing all of them and removing country-specific prefixes. We know the exact point where the school lies and it's LA, so it should be trivial to work out to which classification it belongs.