### PR TITLE
Improve support for legacy systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ refresh: drop_database           \
 download_gias_data:
 	rm -f tmp/*.csv
 	wget https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/${gias_filename} --directory-prefix=${data_dir}
-	iconv tmp/${gias_filename} -f ISO8859-1 -t utf8 -o tmp/${fixed_filename}
+	iconv -f ISO8859-1 -t UTF-8 tmp/${gias_filename} > tmp/${fixed_filename}
 
 drop_database:
 	dropdb --if-exists ${database_name}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ your queries.
 
 * [**Ruby**](https://www.ruby-lang.org/en/), only used for scrubbing and correcting line endings in the GIAS CSV
 * [**GNU Make**](https://www.gnu.org/software/make/), used to run the automatic download and import
+* [**GNU Iconv**](https://www.gnu.org/software/libiconv/), fix file encoding
+* [**GNU Wget**](https://www.gnu.org/software/wget/) for downloading the GIAS CSV file
 * [**PostgreSQL**](https://www.postgresql.org/) with an local superuser account
 * [**PostGIS**](https://postgis.net/) for geographic query goodness
 
@@ -26,14 +28,14 @@ To download, cleanse, import and build the data objects only a single command
 should be required.
 
 ```bash
-$ make
+make
 ```
 
 When debugging, use `make refresh` to run the import steps without repeatedly downloading
 the export file.
 
 ```bash
-$ make refresh
+make refresh
 ```
 
 ## Manual importing
@@ -59,7 +61,6 @@ The importer creates the following database objects:
 | `ofsted_rating`              | `type`              | All Ofsted ratings, including deprecated ones                      |
 | `phase`                      | `type`              | School phases (eg. Secondary, Primary, 16 plus)                    |
 | `rural_urban_classification` | `type`              | Classification of a school's setting, source links in definition   |
-
 
 ## FAQs
 


### PR DESCRIPTION
The `iconv` stage of the import failed on systems with _old_ versions of `libiconv`. On macOS Big Sur, the bundled version dates from 2007 and the arguments (and argument order) vary quite substantially.

This change drops use of the `-o` output file argument and instead relies on `stdout`. It also places the `-f` and `-t` arguments _before_ the filename otherwise the old version of `iconv` interprets them as _actual input_ rather than arguments. 🤷🏽‍♂️ 

Tested on Fedora 33 and macOS Big Sur.

Also updated the prerequisites section of the README and added `wget` and `iconv` entries.