### PR TITLE
Accommodate blank UKPRNs when importing schools

### DIFF
--- a/dml/import_schools.sql
+++ b/dml/import_schools.sql
@@ -40,7 +40,12 @@ insert into schools (
 
 select
 	sr."URN"::integer,
-	sr."UKPRN"::integer,
+	case --ukprn
+	when (sr."UKPRN" is null or sr."UKPRN" = '')
+		then null
+	else
+		sr."UKPRN"::integer
+	end,
 	sr."EstablishmentName",
 	sr."TypeOfEstablishment (name)"::establishment,
 	sr."EstablishmentTypeGroup (name)"::establishment_group,


### PR DESCRIPTION
Fixes a bug I introduced in #15 — I didn't run a full refresh before raising the PR!