### PR TITLE
Add Government Office Region column to schools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ create_types:
 	${psql_command} ${database_name} < ddl/types/ofsted_rating.sql
 	${psql_command} ${database_name} < ddl/types/phase.sql
 	${psql_command} ${database_name} < ddl/types/rural_urban_classification.sql
+	${psql_command} ${database_name} < ddl/types/government_office_regions.sql
 
 create_data_tables:
 	${psql_command} ${database_name} < ddl/tables/create_schools.sql

--- a/ddl/tables/create_schools.sql
+++ b/ddl/tables/create_schools.sql
@@ -16,6 +16,7 @@ create table schools (
 	girls integer,
 	gender gender,
 	coordinates geography(point),
+	government_office_region government_office_region,
 	ofsted_rating ofsted_rating,
 	phase phase,
 	free_school_meals_percentage numeric,

--- a/ddl/types/government_office_regions.sql
+++ b/ddl/types/government_office_regions.sql
@@ -1,0 +1,34 @@
+drop type if exists government_office_region;
+
+/*
+ * UK Government Office Regions
+ * https://wicid.ukdataservice.ac.uk/cider/info.php?geogtype=29
+ *
+ * 1,North East,A
+ * 2,North West,B
+ * 3,Yorkshire and The Humber,D
+ * 4,East Midlands,E
+ * 5,West Midlands,F
+ * 6,East of England,G
+ * 7,London,H
+ * 8,South East,J
+ * 9,South West,K
+ * 10,Wales,W
+ * 11,Scotland,S
+ * 12,Northern Ireland,N
+ */
+
+create type government_office_region as enum (
+	'North East',
+	'North West',
+	'Yorkshire and The Humber',
+	'East Midlands',
+	'West Midlands',
+	'East of England',
+	'London',
+	'South East',
+	'South West',
+	'Wales',
+	'Scotland',
+	'Northern Ireland'
+);

--- a/dml/import_schools.sql
+++ b/dml/import_schools.sql
@@ -28,6 +28,7 @@ insert into schools (
 	ofsted_rating,
 	phase,
 	local_authority,
+	government_office_region,
 	free_school_meals_percentage,
 	start_age,
 	finish_age,
@@ -120,6 +121,16 @@ select
 	nullif(sr."OfstedRating (name)", '')::ofsted_rating,
 	nullif(sr."PhaseOfEducation (name)", '')::phase,
 	sr."LA (name)",
+	case -- government_office_region
+	when sr."GOR (name)" = 'Not Applicable'
+		then null
+	when sr."GOR (name)" = 'Wales (pseudo)'
+		then 'Wales'::government_office_region
+	when sr."GOR (name)" = 'Yorkshire and the Humber'
+		then 'Yorkshire and The Humber'::government_office_region
+	else
+		sr."GOR (name)"::government_office_region
+	end,
 	nullif(sr."PercentageFSM", '')::decimal,
 	nullif(sr."StatutoryLowAge", '')::integer,
 	nullif(sr."StatutoryHighAge", '')::integer,


### PR DESCRIPTION
This should help us filter schools for inclusion or exlusion from comms. For example, we recently included some Welsh schools in comms that weren't relevant to them.
